### PR TITLE
Allow compressors to be registered with CompressorFactory

### DIFF
--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -49,7 +49,24 @@ import java.util.zip.InflaterInputStream;
 
 public class CompressorFactory {
 
+    private static final Map<String, Class<? extends Compressor>> registeredCompressors = defaultCompressors();
+
+    private static Map<String, Class<? extends Compressor>> defaultCompressors() {
+      Map<String, Class<? extends Compressor>> compressors = new HashMap<String, Class<? extends Compressor>>();
+      compressors.put("null", NullCompressor.class);
+      compressors.put("zlib", ZlibCompressor.class);
+      compressors.put("blosc", BloscCompressor.class);
+      return compressors;
+    }
+
     public final static Compressor nullCompressor = new NullCompressor();
+
+
+    public static void registerCompressor(String id, Class<? extends Compressor> compressor) {
+        if (id != null && !registeredCompressors.containsKey(id)) {
+            registeredCompressors.put(id, compressor);
+        }
+    }
 
     /**
      * @return the properties of the default compressor as a key/value map.
@@ -111,14 +128,20 @@ public class CompressorFactory {
      * @throws IllegalArgumentException If it is not able to create a Compressor.
      */
     public static Compressor create(String id, Map<String, Object> properties) {
-        if ("null".equals(id)) {
-            return nullCompressor;
+        try {
+            if (registeredCompressors.containsKey(id)) {
+                Class<? extends Compressor> c = registeredCompressors.get(id);
+                if (c.equals(NullCompressor.class)) {
+                  return nullCompressor;
+                }
+                return c.getDeclaredConstructor(Map.class).newInstance(properties);
+            }
         }
-        if ("zlib".equals(id)) {
-            return new ZlibCompressor(properties);
-        }
-        if ("blosc".equals(id)) {
-            return new BloscCompressor(properties);
+        catch (ReflectiveOperationException e) {
+            if (e.getCause() instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) e.getCause();
+            }
+            throw new IllegalArgumentException("Could not get compressor for id:'" + id + "'", e);
         }
         throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.");
     }
@@ -159,7 +182,7 @@ public class CompressorFactory {
     private static class ZlibCompressor extends Compressor {
         private final int level;
 
-        private ZlibCompressor(Map<String, Object> map) {
+        protected ZlibCompressor(Map<String, Object> map) {
             final Object levelObj = map.get("level");
             if (levelObj == null) {
                 this.level = 1; //default value
@@ -239,7 +262,7 @@ public class CompressorFactory {
         private final int shuffle;
         private final String cname;
 
-        private BloscCompressor(Map<String, Object> map) {
+        protected BloscCompressor(Map<String, Object> map) {
             final Object cnameObj = map.get(keyCname);
             if (cnameObj == null) {
                 cname = defaultCname;

--- a/src/test/java/com/bc/zarr/CompressorFactoryTest.java
+++ b/src/test/java/com/bc/zarr/CompressorFactoryTest.java
@@ -28,6 +28,9 @@ package com.bc.zarr;
 
 import org.junit.Test;
 
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -115,6 +118,34 @@ public class CompressorFactoryTest {
             fail("IllegalArgumentException expected");
         } catch (IllegalArgumentException expected) {
             assertEquals("Compressor id:'kkkkkkk' not supported.", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void registerNewCompressor() {
+        final String id = "test";
+        CompressorFactory.registerCompressor(id, TestCompressor.class);
+        final Compressor compressor = CompressorFactory.create(id, TestUtils.createMap("level", 1));
+        assertNotNull(compressor);
+        assertEquals(id, compressor.getId());
+    }
+
+    static class TestCompressor extends Compressor {
+        public TestCompressor(Map<String, Object> properties) {
+        }
+
+        public String getId() {
+          return "test";
+        }
+
+        public String toString() {
+          return getId();
+        }
+
+        public void compress(InputStream is, OutputStream os) throws IOException {
+        }
+
+        public void uncompress(InputStream is, OutputStream os) throws IOException {
         }
     }
 }


### PR DESCRIPTION
To be considered instead of or in addition to #3.  This makes some minimal changes to ```CompressorFactory``` to allow additional compression ids to be registered and adds a unit test to verify that registration and lookup works.